### PR TITLE
Nonuniform scalars breaks runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+/plots

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ ark-std = "0.3.0"
 ark-ff = "0.3.0"
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 ark-bls12-377 = { version = "0.3.0" }
+home = "0.5.9"
+abomonation = "0.7.3"
+abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
+plotters = "0.3.5"
 
 [build-dependencies]
 cc = "^1.0.70"

--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -27,9 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function(name, |b| {
         b.iter(|| {
             let _ = multi_scalar_mult(&mut context, &points.as_slice(), unsafe {
-                std::mem::transmute::<&[_], &[BigInteger256]>(
-                    scalars.as_slice(),
-                )
+                std::mem::transmute::<&[_], &[BigInteger256]>(scalars.as_slice())
             });
         })
     });

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,6 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let curve = "FEATURE_BLS12_377";
-
     // account for cross-compilation [by examining environment variable]
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
@@ -33,17 +31,15 @@ fn main() {
                 println!("`force-adx` is ignored for non-x86_64 targets");
             }
         }
-        (false, false) => {
+        (false, false) =>
+        {
             #[cfg(target_arch = "x86_64")]
-            if target_arch.eq("x86_64") && std::is_x86_feature_detected!("adx")
-            {
+            if target_arch.eq("x86_64") && std::is_x86_feature_detected!("adx") {
                 println!("Enabling ADX because it was detected on the host");
                 cc_opt = Some("__ADX__");
             }
         }
-        (true, true) => panic!(
-            "Cannot compile with both `portable` and `force-adx` features"
-        ),
+        (true, true) => panic!("Cannot compile with both `portable` and `force-adx` features"),
     }
 
     cc.flag_if_supported("-mno-avx") // avoid costly transitions
@@ -79,7 +75,7 @@ fn main() {
         nvcc.file("yrrid-msm/MSM.cu").compile("msm");
 
         println!("cargo:rustc-cfg=feature=\"cuda\"");
-        println!("cargo:rerun-if-changed=cuda");
+        println!("cargo:rerun-if-changed=yrrid-msm");
         println!("cargo:rerun-if-env-changed=CXXFLAGS");
     } else {
         panic!("nvcc must be in the path. Consider adding /usr/local/cuda/bin.")

--- a/examples/msm.rs
+++ b/examples/msm.rs
@@ -1,0 +1,36 @@
+use std::time::Instant;
+
+use ark_bls12_377::G1Affine;
+use ark_ff::BigInteger256;
+use blst_msm::{
+    multi_scalar_mult, multi_scalar_mult_init,
+    util::{self, generate_nonuniform_scalars},
+};
+
+/// cargo run --release --example msm
+fn main() {
+    let bench_npow: usize = std::env::var("BENCH_NPOW")
+        .unwrap_or("23".to_string())
+        .parse()
+        .unwrap();
+    let npoints_npow = bench_npow;
+
+    let batches = 1;
+    let (points, scalars) =
+        util::generate_points_scalars::<G1Affine>(1usize << npoints_npow, batches);
+
+    let mut context = multi_scalar_mult_init(points.as_slice());
+
+    let start = Instant::now();
+    let res = multi_scalar_mult(&mut context, &points.as_slice(), unsafe {
+        std::mem::transmute::<&[_], &[BigInteger256]>(scalars.as_slice())
+    });
+    println!("random time: {:?}", start.elapsed());
+
+    let nonuniform_scalars = generate_nonuniform_scalars::<G1Affine>(1 << npoints_npow);
+    let start = Instant::now();
+    let res = multi_scalar_mult(&mut context, &points.as_slice(), unsafe {
+        std::mem::transmute::<&[_], &[BigInteger256]>(nonuniform_scalars.as_slice())
+    });
+    println!("nonuniform time: {:?}", start.elapsed());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::os::raw::c_void;
 use ark_bls12_377::{Fr, G1Affine};
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
 use ark_std::Zero;
-
+use std::os::raw::c_void;
 
 #[allow(unused_imports)]
 use blst::*;
@@ -24,45 +23,49 @@ extern "C" {
     // allocate an MSM context (which holds on to GPU memory)
     // specify the max number of points and max number of batches
     fn MSMAllocContext(maxPoints: u32, maxBatches: u32) -> *mut c_void;
-    
+
     // free the context, release GPU memory and resources
     fn MSMFreeContext(context: *mut c_void) -> i32;
-    
+
     // prepare a set of MSM points
-    fn MSMPreprocessPoints(context: *mut c_void, affine_points_ptr: *const G1Affine, points: u32) -> i32;
-    
+    fn MSMPreprocessPoints(
+        context: *mut c_void,
+        affine_points_ptr: *const G1Affine,
+        points: u32,
+    ) -> i32;
+
     // run batches of MSM, using points that were prepared earlier.
-    fn MSMRun(context: *mut c_void, projective_results: *mut u64, scalars_ptr: *const Fr, scalars: u32) -> i32;
+    fn MSMRun(
+        context: *mut c_void,
+        projective_results: *mut u64,
+        scalars_ptr: *const Fr,
+        scalars: u32,
+    ) -> i32;
 }
 
-pub fn multi_scalar_mult_init<G: AffineCurve>(
-    points: &[G],
-) -> MultiScalarMultContext {
-
-    let max_points = 1<<26;
+pub fn multi_scalar_mult_init<G: AffineCurve>(points: &[G]) -> MultiScalarMultContext {
+    let max_points = 1 << 26;
     let max_batches = 16;
     let npoints = points.len();
-    
+
     let ret = MultiScalarMultContext {
-        context: unsafe {
-                   MSMAllocContext(max_points, max_batches)
-                 },
+        context: unsafe { MSMAllocContext(max_points, max_batches) },
     };
 
     let err = unsafe {
-       MSMPreprocessPoints(
-          ret.context, 
-          points as *const _ as *const G1Affine,
-          npoints as u32,
-       )
+        MSMPreprocessPoints(
+            ret.context,
+            points as *const _ as *const G1Affine,
+            npoints as u32,
+        )
     };
-    
+
     if err != 0 {
-      panic!("Error {} occurred in C code", err);
+        panic!("Error {} occurred in C code", err);
     }
     ret
 }
-    
+
 pub fn multi_scalar_mult<G: AffineCurve>(
     context: &mut MultiScalarMultContext,
     points: &[G],
@@ -70,20 +73,20 @@ pub fn multi_scalar_mult<G: AffineCurve>(
 ) -> Vec<G::Projective> {
     let nscalars = scalars.len();
     let batch_size = nscalars / points.len();
-        
+
     let mut ret = vec![G::Projective::zero(); batch_size];
-    
-    let err = unsafe {      
-      MSMRun(
-        context.context, 
-        ret.as_mut_ptr() as *mut u64,
-        scalars as *const _ as *const Fr,
-        nscalars as u32,
-      )
+
+    let err = unsafe {
+        MSMRun(
+            context.context,
+            ret.as_mut_ptr() as *mut u64,
+            scalars as *const _ as *const Fr,
+            nscalars as u32,
+        )
     };
-    
+
     if err != 0 {
-      panic!("Error {} occurred in C code", err);
+        panic!("Error {} occurred in C code", err);
     }
 
     ret

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,35 +2,96 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use rand::SeedableRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::UniformRand;
+use ark_std::{One, Zero};
 
 pub fn generate_points_scalars<G: AffineCurve>(
     len: usize,
-    batches: usize
+    batches: usize,
 ) -> (Vec<G>, Vec<G::ScalarField>) {
     let rand_gen: usize = 1 << 15;
     let mut rng = ChaCha20Rng::from_entropy();
 
-    let mut points =
-        <G::Projective as ProjectiveCurve>::batch_normalization_into_affine(
-            &(0..rand_gen)
-                .map(|_| G::Projective::rand(&mut rng))
-                .collect::<Vec<_>>(),
-        );
+    let mut points = <G::Projective as ProjectiveCurve>::batch_normalization_into_affine(
+        &(0..rand_gen)
+            .map(|_| G::Projective::rand(&mut rng))
+            .collect::<Vec<_>>(),
+    );
     // Sprinkle in some infinity points
-    // points[3] = G::zero(); 
+    // points[3] = G::zero();
     while points.len() < len {
         points.append(&mut points.clone());
     }
 
-    let scalars = (0..len*batches)
+    let scalars = (0..len * batches)
         .map(|_| G::ScalarField::rand(&mut rng))
         .collect::<Vec<_>>();
 
     (points, scalars)
 }
 
+/// Generate non-uniform scalars. For now we model after the lurk witness
+/// which has ~20k over-represented values that occur ~300 times on average,
+/// but can go up to ~1000s.
+///
+/// Hence we do:
+/// - A few (<10) small values that occur at very high frequency,
+///   mostly to represent special values like 0,1,2^32,2^64
+/// - A few hundred random values that occur in the thousands
+/// - ~20k values that occur between 200-400 times
+/// - fill remaining length with random values
+pub fn generate_nonuniform_scalars<G: AffineCurve>(len: usize) -> Vec<G::ScalarField> {
+    assert!(len >= (1 << 23)); // fine tuned for this number lmao
+
+    let mut rng = ChaCha20Rng::from_entropy();
+    let mut scalars = Vec::with_capacity(len);
+
+    // special values 200_000
+    for _ in 0..150_000 {
+        scalars.push(G::ScalarField::zero());
+    }
+    for _ in 0..50_000 {
+        scalars.push(G::ScalarField::one());
+    }
+
+    // high freq: 250 * 6000 = 1_500_000
+    let n_high_freq = rng.gen_range(200..300);
+    let high_freq = (0..n_high_freq)
+        .map(|_| G::ScalarField::rand(&mut rng))
+        .collect::<Vec<_>>();
+
+    for val in high_freq {
+        let freq = rng.gen_range(4000..8000);
+        for _ in 0..freq {
+            scalars.push(val);
+        }
+    }
+
+    // low freq: 20_000 * 300 = 3_000_000
+    let n_low_freq = rng.gen_range(19_000..21_000);
+    let low_freq = (0..n_low_freq)
+        .map(|_| G::ScalarField::rand(&mut rng))
+        .collect::<Vec<_>>();
+
+    for val in low_freq {
+        let freq = rng.gen_range(200..400);
+        for _ in 0..freq {
+            scalars.push(val);
+        }
+    }
+
+    let n_rest = len - scalars.len();
+    for _ in 0..n_rest {
+        scalars.push(G::ScalarField::rand(&mut rng));
+    }
+
+    scalars.shuffle(&mut rng);
+
+    assert_eq!(scalars.len(), len);
+    scalars
+}

--- a/tests/msm.rs
+++ b/tests/msm.rs
@@ -4,8 +4,8 @@
 
 use ark_bls12_377::G1Affine;
 use ark_ec::msm::VariableBaseMSM;
-use ark_ff::BigInteger256;
 use ark_ec::ProjectiveCurve;
+use ark_ff::BigInteger256;
 
 use std::str::FromStr;
 
@@ -24,14 +24,13 @@ fn msm_correctness() {
     let msm_results = multi_scalar_mult(&mut context, points.as_slice(), unsafe {
         std::mem::transmute::<&[_], &[BigInteger256]>(scalars.as_slice())
     });
-                                                 
+
     for b in 0..batches {
         let start = b * points.len();
         let end = (b + 1) * points.len();
 
-        let arkworks_result =
-            VariableBaseMSM::multi_scalar_mul(points.as_slice(), unsafe {
-                std::mem::transmute::<&[_], &[BigInteger256]>(&scalars[start..end])
+        let arkworks_result = VariableBaseMSM::multi_scalar_mul(points.as_slice(), unsafe {
+            std::mem::transmute::<&[_], &[BigInteger256]>(&scalars[start..end])
         })
         .into_affine();
 


### PR DESCRIPTION
Hello! I've been looking around at the best GPU MSM implementations and yours was at the top of ZPrize 2022. On your deep dive on YouTube ([this one](https://www.youtube.com/watch?v=KAWlySN7Hm8)), there were a few mentions/questions on whether or not having unbalanced buckets would impact the performance. I ended up being too curious not to see for myself and wrote a short test to see the actual numbers. However, this apparently breaks the program.

I've added an example in `examples/msm.rs` within the PR to reproduce the breakage. Running the example, we have:
```
winston-h-zhang$ cargo run --release --example msm
   Compiling blst-msm v0.1.0 (/home/winston-h-zhang/submission-msm-gpu)
    Finished release [optimized] target(s) in 11.86s
     Running `target/release/examples/msm`
Initial copy: 29.045759 ms
Total time: 113.095779 ms
random time: 120.643228ms
CUDA Error 700 occurred on "Call "cudaEventSynchronize(lastRoundPlanningComplete)" failed.", in yrrid-msm/MSM.cu:479
thread 'main' panicked at /home/winston-h-zhang/submission-msm-gpu/src/lib.rs:89:9:
Error 700 occurred in C code
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I first run a vector of random scalars, which works fine. Then I generate a vector of nonuniform scalars (more info in the doc-comment above `generate_nonuniform_scalars`), and when I run it with these scalars the program panics. Maybe there is some other configuration breaking something? I haven't looked closely at the codebase. I would appreciate any response and would love to know why this is happening/how to possibly fix this! 

Apologies if this isn't the best way to communicate with you, but I thought a PR would most direct. Thank you in advance!

Hardware specs:

NVIDIA RTX A6000
48 GB RAM
8 CPU Intel Xeon Silver 4215R